### PR TITLE
Add JUMP_TO_STATE action for slider-like monitors

### DIFF
--- a/src/react/LogMonitor.js
+++ b/src/react/LogMonitor.js
@@ -4,6 +4,7 @@ import LogMonitorEntry from './LogMonitorEntry';
 export default class LogMonitor {
   static propTypes = {
     computedStates: PropTypes.array.isRequired,
+    currentStateIndex: PropTypes.number.isRequired,
     stagedActions: PropTypes.array.isRequired,
     skippedActions: PropTypes.object.isRequired,
     reset: PropTypes.func.isRequired,


### PR DESCRIPTION
I challenged you to implement slider-like custom monitors in #3, but in fact I forget something essential to make it easy.

The built-in `LogMonitor` lets you “toggle” individual actions, disabling them from history. This is not what slider interface is like though: a slider just moves back and forward in time between the computed state. It does not really alter the history: it only alters the **current** state we are looking at.

This PR adds another devtools action: `JUMP_TO_STATE`. By default, the `currentStateIndex` will advance any time an action is performed, but your custom monitor can also call `this.props.jumpToState({ index: 0 })` to jump to the first state, or something in the middle (make sure to to put there values larger than `this.props.computedStates.length - 1`.

The default `LogMonitor` does not use `this.props.jumpToState` at all, but your custom monitor may use it, as well as `this.props.currentStateIndex`, to implement a slider-like UI.