### PR TITLE
Implement toggle

### DIFF
--- a/src/devTools.js
+++ b/src/devTools.js
@@ -86,7 +86,7 @@ function liftReducer(reducer, initialState) {
     skippedActions: {},
     currentStateIndex: 0,
     monitorState: {
-      isVisible: true,
+      isVisible: true
     }
   };
 
@@ -141,12 +141,12 @@ function liftReducer(reducer, initialState) {
       break;
     case ActionTypes.HIDE:
       monitorState = {
-        isVisible: false,
+        isVisible: false
       };
       break;
     case ActionTypes.SHOW:
       monitorState = {
-        isVisible: true,
+        isVisible: true
       };
       break;
     default:
@@ -222,10 +222,10 @@ export const ActionCreators = {
     return { type: ActionTypes.SWEEP };
   },
   show() {
-    return { type: ActionTypes.SHOW }
+    return { type: ActionTypes.SHOW };
   },
   hide() {
-    return { type: ActionTypes.HIDE }
+    return { type: ActionTypes.HIDE };
   },
   toggleAction(index) {
     return { type: ActionTypes.TOGGLE_ACTION, index };

--- a/src/devTools.js
+++ b/src/devTools.js
@@ -84,7 +84,10 @@ function liftReducer(reducer, initialState) {
     committedState: initialState,
     stagedActions: [INIT_ACTION],
     skippedActions: {},
-    currentStateIndex: 0
+    currentStateIndex: 0,
+    monitorState: {
+      isVisible: true,
+    }
   };
 
   /**
@@ -96,7 +99,8 @@ function liftReducer(reducer, initialState) {
       stagedActions,
       skippedActions,
       computedStates,
-      currentStateIndex
+      currentStateIndex,
+      monitorState
     } = liftedState;
 
     switch (liftedAction.type) {
@@ -135,6 +139,16 @@ function liftReducer(reducer, initialState) {
       }
       stagedActions = [...stagedActions, action];
       break;
+    case ActionTypes.HIDE:
+      monitorState = {
+        isVisible: false,
+      };
+      break;
+    case ActionTypes.SHOW:
+      monitorState = {
+        isVisible: true,
+      };
+      break;
     default:
       break;
     }
@@ -151,7 +165,8 @@ function liftReducer(reducer, initialState) {
       stagedActions,
       skippedActions,
       computedStates,
-      currentStateIndex
+      currentStateIndex,
+      monitorState
     };
   };
 }

--- a/src/devTools.js
+++ b/src/devTools.js
@@ -5,7 +5,9 @@ const ActionTypes = {
   COMMIT: 'COMMIT',
   SWEEP: 'SWEEP',
   TOGGLE_ACTION: 'TOGGLE_ACTION',
-  JUMP_TO_STATE: 'JUMP_TO_STATE'
+  JUMP_TO_STATE: 'JUMP_TO_STATE',
+  HIDE: 'HIDE',
+  SHOW: 'SHOW'
 };
 
 const INIT_ACTION = {
@@ -203,6 +205,12 @@ export const ActionCreators = {
   },
   sweep() {
     return { type: ActionTypes.SWEEP };
+  },
+  show() {
+    return { type: ActionTypes.SHOW }
+  },
+  hide() {
+    return { type: ActionTypes.HIDE }
   },
   toggleAction(index) {
     return { type: ActionTypes.TOGGLE_ACTION, index };

--- a/src/react/DebugPanel.js
+++ b/src/react/DebugPanel.js
@@ -17,7 +17,6 @@ export function getDefaultStyle(props) {
     opacity: 0.92,
     background: 'black',
     color: 'white',
-    padding: '1em',
     left: left ? 0 : undefined,
     right: right ? 0 : undefined,
     top: top ? 0 : undefined,

--- a/src/react/LogMonitor.js
+++ b/src/react/LogMonitor.js
@@ -2,6 +2,10 @@ import React, { PropTypes, findDOMNode } from 'react';
 import LogMonitorEntry from './LogMonitorEntry';
 
 export default class LogMonitor {
+  constructor() {
+    window.addEventListener('keypress', ::this.handleKeyPress);
+  }
+
   static propTypes = {
     computedStates: PropTypes.array.isRequired,
     currentStateIndex: PropTypes.number.isRequired,
@@ -64,6 +68,18 @@ export default class LogMonitor {
 
   handleReset() {
     this.props.reset();
+  }
+
+  handleKeyPress(event) {
+    let { isVisible } = this.props.monitorState;
+
+    if (event.ctrlKey && event.keyCode === 8) {
+      if (isVisible) {
+        this.props.hide();
+      } else {
+        this.props.show();
+      }
+    }
   }
 
   render() {

--- a/src/react/LogMonitor.js
+++ b/src/react/LogMonitor.js
@@ -105,47 +105,59 @@ export default class LogMonitor {
       );
     }
 
-    return (
-      <div style={{
-        fontFamily: 'monospace',
-        position: 'relative'
-      }}>
-        <div>
-          <a onClick={::this.handleReset}
-             style={{ textDecoration: 'underline', cursor: 'hand' }}>
-            Reset
-          </a>
-        </div>
-        {elements}
-        <div>
-          {computedStates.length > 1 &&
-            <a onClick={::this.handleRollback}
-               style={{ textDecoration: 'underline', cursor: 'hand' }}>
-              Rollback
-            </a>
-          }
-          {Object.keys(skippedActions).some(key => skippedActions[key]) &&
-            <span>
-              {' • '}
-              <a onClick={::this.handleSweep}
+    if (this.props.monitorState.isVisible === true) {
+      return (
+        <div style={{
+          fontFamily: 'monospace',
+          position: 'relative',
+          padding: '1rem'
+        }}>
+          <div>
+            <div style={{
+              paddingBottom: '.5rem'
+            }}>
+              <small>Press `ctl+h` to hide.</small>
+            </div>
+            <div>
+              <a onClick={::this.handleReset}
                  style={{ textDecoration: 'underline', cursor: 'hand' }}>
-                Sweep
+                <small>Reset</small>
               </a>
-            </span>
-          }
-          {computedStates.length > 1 &&
-            <span>
+            </div>
+          </div>
+          {elements}
+          <div>
+            {computedStates.length > 1 &&
+              <a onClick={::this.handleRollback}
+                 style={{ textDecoration: 'underline', cursor: 'hand' }}>
+                Rollback
+              </a>
+            }
+            {Object.keys(skippedActions).some(key => skippedActions[key]) &&
               <span>
-              {' • '}
+                {' • '}
+                <a onClick={::this.handleSweep}
+                   style={{ textDecoration: 'underline', cursor: 'hand' }}>
+                  Sweep
+                </a>
               </span>
-              <a onClick={::this.handleCommit}
-                 style={{ textDecoration: 'underline', cursor: 'hand' }}>
-                Commit
-              </a>
-            </span>
-          }
+            }
+            {computedStates.length > 1 &&
+              <span>
+                <span>
+                {' • '}
+                </span>
+                <a onClick={::this.handleCommit}
+                   style={{ textDecoration: 'underline', cursor: 'hand' }}>
+                  Commit
+                </a>
+              </span>
+            }
+          </div>
         </div>
-      </div>
-    );
+      );
+    }
+
+    return false;
   }
 }

--- a/src/react/LogMonitor.js
+++ b/src/react/LogMonitor.js
@@ -9,9 +9,12 @@ export default class LogMonitor {
   static propTypes = {
     computedStates: PropTypes.array.isRequired,
     currentStateIndex: PropTypes.number.isRequired,
+    monitorState: PropTypes.object.isRequired,
     stagedActions: PropTypes.array.isRequired,
     skippedActions: PropTypes.object.isRequired,
     reset: PropTypes.func.isRequired,
+    hide: PropTypes.func.isRequired,
+    show: PropTypes.func.isRequired,
     commit: PropTypes.func.isRequired,
     rollback: PropTypes.func.isRequired,
     sweep: PropTypes.func.isRequired,


### PR DESCRIPTION
- Adds `monitorState` object to track the state of the monitor, e.g., if it is visible or not.
- Adds `show()` action creator to show monitor
- Adds `hide()` action creator to hide monitor
- Moves the padding from the monitor container to the monitor itself; having the padding on the container prevented the monitor from being fully hidden.
- Adds some help text at the top of the monitor to explain how to hide the monitor.