### PR TITLE
Fixes Issue #14

### DIFF
--- a/src/react/LogMonitor.js
+++ b/src/react/LogMonitor.js
@@ -3,7 +3,7 @@ import LogMonitorEntry from './LogMonitorEntry';
 
 export default class LogMonitor {
   constructor() {
-    window.addEventListener('keypress', ::this.handleKeyPress);
+    window.addEventListener('keydown', ::this.handleKeyPress);
   }
 
   static propTypes = {
@@ -76,7 +76,8 @@ export default class LogMonitor {
   handleKeyPress(event) {
     let { isVisible } = this.props.monitorState;
 
-    if (event.ctrlKey && event.keyCode === 8) {
+    if (event.ctrlKey && event.keyCode === 72) {
+      event.preventDefault();
       if (isVisible) {
         this.props.hide();
       } else {


### PR DESCRIPTION
- Changed keypress event to keydownd event. In Chrome + Linux, the keypress event don't return ctrlKey event. ( Fixes issue #14 );
- Added event.preventDefault() to prevent default behavior from Browsers;
- Changed keyCode 8 to 72 to properly refer to 'h' key
