### PR TITLE
reducer exception shown in console

### DIFF
--- a/src/devTools.js
+++ b/src/devTools.js
@@ -40,6 +40,7 @@ function computeNextEntry(reducer, action, state, error) {
     nextState = reducer(state, action);
   } catch (err) {
     nextError = err.toString();
+    console.error(err.stack || err);
   }
 
   return {


### PR DESCRIPTION
Error thrown in reducer is consumed and only message is shown. This PR adds call to `console.error` to see a stack trace.