### PR TITLE
"splicing" actions

### DIFF
--- a/src/devTools.js
+++ b/src/devTools.js
@@ -135,8 +135,12 @@ function liftReducer(reducer, initialState) {
     case ActionTypes.PERFORM_ACTION:
       if (currentStateIndex === stagedActions.length - 1) {
         currentStateIndex++;
+        stagedActions = [...stagedActions, liftedAction.action];
+      } else {
+        stagedActions = stagedActions.slice(0, currentStateIndex + 1).concat(liftedAction.action);
+        currentStateIndex = stagedActions.length - 1;
+        skippedActions = {};
       }
-      stagedActions = [...stagedActions, liftedAction.action];
       break;
     case ActionTypes.SET_MONITOR_STATE:
       monitorState = liftedAction.monitorState;


### PR DESCRIPTION
This is a somewhat quick-and-dirty approach to #34. I first went with the suggested "spliceActions" approach, but I realized I'd have to keep track of the lifted action and then manually dispatch ```performAction``` with somewhere else.

Also, this doesn't do much to address ```skippedActions```.

I imagine that in most cases, if you want to fire new actions after calling ```jumpToState```, you would want the action to update the state currently being viewed, rather than jumping to the end of the log and appending there. However, I can understand if this doesn't seem like a universal-enough use case to where you'd merge it.