### PR TITLE
ensure window exists for universal rendering

### DIFF
--- a/src/react/LogMonitor.js
+++ b/src/react/LogMonitor.js
@@ -3,7 +3,9 @@ import LogMonitorEntry from './LogMonitorEntry';
 
 export default class LogMonitor {
   constructor() {
-    window.addEventListener('keydown', ::this.handleKeyPress);
+    if (typeof window !== 'undefined') {
+      window.addEventListener('keydown', ::this.handleKeyPress);
+    }
   }
 
   static propTypes = {


### PR DESCRIPTION
title pretty much says what I’m going for. :)

I’m not sure if this makes sense for the devtools to support universal rendering since there may be actions being run on the server that aren’t run on the client one might not want exposed, but seeing as this is a tool for dev time I don’t think that is much of a risk (since it shouldn’t be run in production).