### PR TITLE
LogMonitor now attempts to call .toJS() on state entries.

### DIFF
--- a/src/react/LogMonitor.js
+++ b/src/react/LogMonitor.js
@@ -144,6 +144,20 @@ export default class LogMonitor {
       const action = stagedActions[i];
       const { state, error } = computedStates[i];
       let previousState;
+
+      const readableState = {};
+      for (const prop in state) {
+        if (
+          state.hasOwnProperty(prop) &&
+          typeof state[prop] === 'object' &&
+          typeof state[prop].toJS === 'function'
+        ) {
+          readableState = state[prop].toJS();
+        } else {
+          readableState = state[prop];
+        }
+      }
+
       if (i > 0) {
         previousState = computedStates[i - 1].state;
       }
@@ -153,7 +167,7 @@ export default class LogMonitor {
                          theme={theme}
                          select={select}
                          action={action}
-                         state={state}
+                         state={readableState}
                          previousState={previousState}
                          collapsed={skippedActions[i]}
                          error={error}


### PR DESCRIPTION
This is an attempt to fix the unreadable state entries for ImmutableJS. I really didn't want to do the manipulation in the render method, but from what I saw in terms of how states are computed and stored I couldn't think of a better solution that didn't significantly alter that part of the codebase.

Anyways, feedback is appreciated. Maybe somebody has a better solution in mind, but this seems to be working for me.