### PR TITLE
add visibleOnLoad props to LogMonitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ A live-editing time travel environment for [Redux](https://github.com/rackt/redu
 * If you change the reducer code, each “staged” action will be re-evaluted
 * If the reducers throw, you will see during which action this happened, and what the error was
 * With `persistState()` store enhancer, you can persist debug sessions across page reloads
-* To monitor a part of  the state, you can set a `select` prop on the DevTools component: `<DevTools select={state => state.todos} store={store} monitor={LogMonitor} />`
+* To monitor a part of the state, you can set a `select` prop on the DevTools component: `<DevTools select={state => state.todos} store={store} monitor={LogMonitor} />`
 * Toggle visibility with Ctrl+H
+* To hide the devtools on load, set `visibleOnLoad` to false, e.g.: `<DevTools store={store} monitor={LogMonitor} visibleOnLoad={false} />`
 
 ### Installation
 

--- a/examples/counter/containers/App.js
+++ b/examples/counter/containers/App.js
@@ -26,7 +26,7 @@ export default class App extends Component {
         </Provider>
         <DebugPanel top right bottom>
           <DevTools store={store}
-                    monitor={LogMonitor} />
+                    monitor={LogMonitor} visibleOnLoad={true} />
         </DebugPanel>
       </div>
     );

--- a/src/react/LogMonitor.js
+++ b/src/react/LogMonitor.js
@@ -52,13 +52,15 @@ export default class LogMonitor {
     toggleAction: PropTypes.func.isRequired,
     jumpToState: PropTypes.func.isRequired,
     setMonitorState: PropTypes.func.isRequired,
-    select: PropTypes.func.isRequired
+    select: PropTypes.func.isRequired,
+    visibleOnLoad: PropTypes.bool
   };
 
   static defaultProps = {
     select: (state) => state,
     monitorState: { isVisible: true },
-    theme: 'nicinabox'
+    theme: 'nicinabox',
+    visibleOnLoad: true
   };
 
   componentWillReceiveProps(nextProps) {
@@ -88,6 +90,15 @@ export default class LogMonitor {
       node.scrollTop = scrollHeight - offsetHeight;
       this.scrollDown = false;
     }
+  }
+
+  componentWillMount() {
+    let visibleOnLoad = this.props.visibleOnLoad;
+    const { monitorState } = this.props;
+    this.props.setMonitorState({
+      ...monitorState,
+      isVisible: visibleOnLoad
+    });
   }
 
   handleRollback() {


### PR DESCRIPTION
I'm not sure whether to use `componentWillMount` or `componentDidMount`. But both seems to work, and `componentWillMount` won't trigger another `render`.

But are we changing props indirectly here right? Is this the right way to go?