### PR TITLE
custom parsers for persistState

### DIFF
--- a/src/persistState.js
+++ b/src/persistState.js
@@ -1,6 +1,50 @@
-export default function persistState(sessionId) {
+export default function persistState(sessionId, parsers) {
   if (!sessionId) {
     return next => (...args) => next(...args);
+  }
+
+  function callParser(parserMethod, parserName, stateSlice) {
+    const parser = parsers[parserName];
+    if (parser && typeof parser[parserMethod] === 'function') {
+      return parser[parserMethod](stateSlice);
+    }
+    return stateSlice;
+  }
+
+  // function serializeState(state) {
+  //   if (!state) {
+  //     return state;
+  //   }
+  //   return Object.keys(state).reduce((serialized, sliceName) => {
+  //     serialized[sliceName] = callParser('serialize', sliceName, state[sliceName]);
+  //     return serialized;
+  //   }, {});
+  // }
+
+  function deserializeState(state) {
+    if (!state) {
+      return state;
+    }
+    return Object.keys(state).reduce((deserialized, sliceName) => {
+      deserialized[sliceName] = callParser('deserialize', sliceName, state[sliceName]);
+      return deserialized;
+    }, {});
+  }
+
+  function parseState(fullState) {
+    if (!fullState || !parsers) {
+      return fullState;
+    }
+    return {
+      ...fullState,
+      committedState: deserializeState(fullState.committedState),
+      computedStates: fullState.computedStates.map((computedState) => {
+        return {
+          ...computedState,
+          state: deserializeState(computedState.state)
+        };
+      })
+    };
   }
 
   return next => (reducer, initialState) => {
@@ -8,7 +52,7 @@ export default function persistState(sessionId) {
 
     let finalInitialState;
     try {
-      finalInitialState = JSON.parse(localStorage.getItem(key)) || initialState;
+      finalInitialState = parseState(JSON.parse(localStorage.getItem(key))) || initialState;
       next(reducer, initialState);
     } catch (e) {
       console.warn('Could not read debug session from localStorage:', e);

--- a/src/persistState.js
+++ b/src/persistState.js
@@ -1,47 +1,19 @@
-export default function persistState(sessionId, parsers) {
+export default function persistState(sessionId, deserializer = null) {
   if (!sessionId) {
     return next => (...args) => next(...args);
   }
 
-  function callParser(parserMethod, parserName, stateSlice) {
-    const parser = parsers[parserName];
-    if (parser && typeof parser[parserMethod] === 'function') {
-      return parser[parserMethod](stateSlice);
-    }
-    return stateSlice;
-  }
-
-  // function serializeState(state) {
-  //   if (!state) {
-  //     return state;
-  //   }
-  //   return Object.keys(state).reduce((serialized, sliceName) => {
-  //     serialized[sliceName] = callParser('serialize', sliceName, state[sliceName]);
-  //     return serialized;
-  //   }, {});
-  // }
-
-  function deserializeState(state) {
-    if (!state) {
-      return state;
-    }
-    return Object.keys(state).reduce((deserialized, sliceName) => {
-      deserialized[sliceName] = callParser('deserialize', sliceName, state[sliceName]);
-      return deserialized;
-    }, {});
-  }
-
-  function parseState(fullState) {
-    if (!fullState || !parsers) {
+  function deserializeState(fullState) {
+    if (!fullState || typeof deserializer !== 'function') {
       return fullState;
     }
     return {
       ...fullState,
-      committedState: deserializeState(fullState.committedState),
+      committedState: deserializer(fullState.committedState),
       computedStates: fullState.computedStates.map((computedState) => {
         return {
           ...computedState,
-          state: deserializeState(computedState.state)
+          state: deserializer(computedState.state)
         };
       })
     };
@@ -52,7 +24,7 @@ export default function persistState(sessionId, parsers) {
 
     let finalInitialState;
     try {
-      finalInitialState = parseState(JSON.parse(localStorage.getItem(key))) || initialState;
+      finalInitialState = deserializeState(JSON.parse(localStorage.getItem(key))) || initialState;
       next(reducer, initialState);
     } catch (e) {
       console.warn('Could not read debug session from localStorage:', e);


### PR DESCRIPTION
Since I am using ImmutableJS for my state, the current `persistState` cannot work properly there, eg. my state is List of Record instances. This cannot be solved in some generic way. So I made this modification which allows me to pass this object as a second argument to `persistState` middleware.

    const TGDocumentParser = {
        serialize(state) {
            return state.toJS();
        },
        deserialize(state) {
            return Imm.List(state.map((row) => new TGRow(row)));
        }
    };

    persistState(sessionId, {
        tgDocument: TGDocumentParser
    });

Each state slice can have a different parser. The actual serialization isn't implemented yet and I am wondering it it's needed. Immutable can serialize just fine. I am not sure about other structures like mori or es6. What do you think?