### PR TITLE
Add link to Redux project in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Redux DevTools
 =========================
 
-A live-editing time travel environment for Redux.  
+A live-editing time travel environment for [Redux](https://github.com/rackt/redux).  
 **[See Dan's React Europe talk demoing it!](http://youtube.com/watch?v=xsSnOQynTHs)**
 
 ![](http://i.imgur.com/J4GeW0M.gif)


### PR DESCRIPTION
This PR adds a link to the redux project on Github. 

This makes sense if people discover the devtools via Social Media ("OMG look at this: redux-devtools") but are not familar with Redux/React/etc. :+1: