### PR TITLE
Remove NoErrorsPlugin

### DIFF
--- a/examples/counter/package.json
+++ b/examples/counter/package.json
@@ -25,7 +25,7 @@
     "babel-core": "^5.6.18",
     "babel-loader": "^5.1.4",
     "node-libs-browser": "^0.5.2",
-    "react-hot-loader": "^1.2.7",
+    "react-hot-loader": "^1.3.0",
     "webpack": "^1.9.11",
     "webpack-dev-server": "^1.9.0"
   }

--- a/examples/counter/webpack.config.js
+++ b/examples/counter/webpack.config.js
@@ -14,8 +14,7 @@ module.exports = {
     publicPath: '/static/'
   },
   plugins: [
-    new webpack.HotModuleReplacementPlugin(),
-    new webpack.NoErrorsPlugin()
+    new webpack.HotModuleReplacementPlugin()
   ],
   resolve: {
     alias: {

--- a/examples/todomvc/package.json
+++ b/examples/todomvc/package.json
@@ -38,7 +38,7 @@
     "babel-loader": "^5.1.4",
     "node-libs-browser": "^0.5.2",
     "raw-loader": "^0.5.1",
-    "react-hot-loader": "^1.2.7",
+    "react-hot-loader": "^1.3.0",
     "style-loader": "^0.12.3",
     "todomvc-app-css": "^2.0.1",
     "webpack": "^1.9.11",

--- a/examples/todomvc/webpack.config.js
+++ b/examples/todomvc/webpack.config.js
@@ -14,8 +14,7 @@ module.exports = {
     publicPath: '/static/'
   },
   plugins: [
-    new webpack.HotModuleReplacementPlugin(),
-    new webpack.NoErrorsPlugin()
+    new webpack.HotModuleReplacementPlugin()
   ],
   resolve: {
     alias: {


### PR DESCRIPTION
React Hot Loader 1.3.0 fixes a [problem that caused `NoErrorsPlugin` to be necessary](https://github.com/gaearon/react-hot-loader/pull/187#issuecomment-135884631). In fact now errors thrown on module level shouldn't prevent future hot reloading of the same file after you fix the problem.