### PR TITLE
add actionDeserializer callback to persistState

### DIFF
--- a/src/persistState.js
+++ b/src/persistState.js
@@ -1,20 +1,32 @@
-export default function persistState(sessionId, deserializer = null) {
+export default function persistState(sessionId, stateDeserializer = null, actionDeserializer = null) {
   if (!sessionId) {
     return next => (...args) => next(...args);
   }
 
   function deserializeState(fullState) {
-    if (!fullState || typeof deserializer !== 'function') {
+    if (!fullState || typeof stateDeserializer !== 'function') {
       return fullState;
     }
     return {
       ...fullState,
-      committedState: deserializer(fullState.committedState),
+      committedState: stateDeserializer(fullState.committedState),
       computedStates: fullState.computedStates.map((computedState) => {
         return {
           ...computedState,
-          state: deserializer(computedState.state)
+          state: stateDeserializer(computedState.state)
         };
+      })
+    };
+  }
+
+  function deserializeActions(fullState) {
+    if (!fullState || typeof actionDeserializer !== 'function') {
+      return fullState;
+    }
+    return {
+      ...fullState,
+      stagedActions: fullState.stagedActions.map((action) => {
+        return actionDeserializer(action);
       })
     };
   }
@@ -24,7 +36,7 @@ export default function persistState(sessionId, deserializer = null) {
 
     let finalInitialState;
     try {
-      finalInitialState = deserializeState(JSON.parse(localStorage.getItem(key))) || initialState;
+      finalInitialState = deserializeActions(deserializeState(JSON.parse(localStorage.getItem(key)))) || initialState;
       next(reducer, initialState);
     } catch (e) {
       console.warn('Could not read debug session from localStorage:', e);


### PR DESCRIPTION
Because of some fancy middleware caching, I found that it was best if I passed Immutable objects through actions. They become plain objects after they get serialized in `persistState`, so I added a third argument to `persistState`, similar to #78

Example:

```es

function actionDeserializer(action) {
  if (action.type === 'SOME_ACTION_WITH_IMMUTABLE_PAYLOAD') {
    return {
      ...action,
      payload: Immutable.fromJS(action.payload)
    }
  }
  return action
}
persistState(sessionId, null, actionDeserializer)

```

This would also be useful for the folks who are using symbols instead of string constants for action types.