### PR TITLE
avoid react@0.14.0-rc1 warnings

### DIFF
--- a/src/react/DebugPanel.js
+++ b/src/react/DebugPanel.js
@@ -28,7 +28,7 @@ export function getDefaultStyle(props) {
   };
 }
 
-export default class DebugPanel {
+export default class DebugPanel extends React.Component {
   static propTypes = {
     left: PropTypes.bool,
     right: PropTypes.bool,

--- a/src/react/LogMonitor.js
+++ b/src/react/LogMonitor.js
@@ -1,4 +1,4 @@
-import React, { PropTypes, findDOMNode } from 'react';
+import React, { PropTypes } from 'react';
 import LogMonitorEntry from './LogMonitorEntry';
 import LogMonitorButton from './LogMonitorButton';
 import * as themes from './themes';
@@ -32,8 +32,9 @@ const styles = {
   }
 };
 
-export default class LogMonitor {
-  constructor() {
+export default class LogMonitor extends React.Component {
+  constructor(props) {
+    super(props);
     if (typeof window !== 'undefined') {
       window.addEventListener('keydown', ::this.handleKeyPress);
     }
@@ -64,7 +65,7 @@ export default class LogMonitor {
   };
 
   componentWillReceiveProps(nextProps) {
-    const node = findDOMNode(this.refs.elements);
+    const node = this.refs.elements;
     if (!node) {
       this.scrollDown = true;
     } else if (
@@ -81,7 +82,7 @@ export default class LogMonitor {
   }
 
   componentDidUpdate() {
-    const node = findDOMNode(this.refs.elements);
+    const node = this.refs.elements;
     if (!node) {
       return;
     }

--- a/src/react/LogMonitorEntry.js
+++ b/src/react/LogMonitorEntry.js
@@ -12,7 +12,7 @@ const styles = {
   }
 };
 
-export default class LogMonitorEntry {
+export default class LogMonitorEntry extends React.Component {
   static propTypes = {
     index: PropTypes.number.isRequired,
     state: PropTypes.object.isRequired,


### PR DESCRIPTION
I've added extend React.Component to the classes that were missing it and removed references to findDomNode to avoid warnings with react@0.14.0-rc1. 