### PR TITLE
React 0.14: Use of react-dom has moved findDOMNode

### DIFF
--- a/src/react/LogMonitor.js
+++ b/src/react/LogMonitor.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, findDOMNode, Component } from 'react';
+import React, { PropTypes, Component } from 'react';
+import { findDOMNode } from 'react-dom';
 import LogMonitorEntry from './LogMonitorEntry';
 import LogMonitorButton from './LogMonitorButton';
 import * as themes from './themes';


### PR DESCRIPTION
As mentioned in [this post](https://facebook.github.io/react/blog/2015/07/03/react-v0.14-beta-1.html) `react-dom`has a number of methods originally part of `react`. One of these methods is `findDOMNode` which is used by `LogMonitor`.

This commit uses `findDOMNode` from `react-dom` as per advice issued in the deprecation warning.