### PR TITLE
Bump react-json-tree 0.1.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "redux": "^2.0.0 || ^3.0.0"
   },
   "dependencies": {
-    "react-json-tree": "^0.1.8",
+    "react-json-tree": "^0.1.9",
     "react-mixin": "^1.7.0",
     "react-redux": "^2.0.0",
     "redux": "^2.0.0 || ^3.0.0"


### PR DESCRIPTION
@dzannotti helped increase the performance of `react-json-tree` - it doesn't use deep equality check anymore, so it should be much faster. I put it on 0.1.9. The details are on this commit:

https://github.com/chibicode/react-json-tree/commit/b550c73770ff5a5b41f0d747044b7a6ac2b65eb7