### PR TITLE
LogMonitor: remove calls to findDOMNode

### DIFF
--- a/src/react/LogMonitor.js
+++ b/src/react/LogMonitor.js
@@ -1,4 +1,4 @@
-import React, { PropTypes, findDOMNode, Component } from 'react';
+import React, { PropTypes, Component } from 'react';
 import LogMonitorEntry from './LogMonitorEntry';
 import LogMonitorButton from './LogMonitorButton';
 import * as themes from './themes';
@@ -65,7 +65,7 @@ export default class LogMonitor extends Component {
   };
 
   componentWillReceiveProps(nextProps) {
-    const node = findDOMNode(this.refs.elements);
+    const node = this.refs.elements;
     if (!node) {
       this.scrollDown = true;
     } else if (
@@ -82,7 +82,7 @@ export default class LogMonitor extends Component {
   }
 
   componentDidUpdate() {
-    const node = findDOMNode(this.refs.elements);
+    const node = this.refs.elements;
     if (!node) {
       return;
     }


### PR DESCRIPTION
`React.findDOMNode()` is deprecated and not a necessity anymore.
This patch should be merged and published after react-0.14.*-stable is out. (as discussed in #110)

While doing this i noticed that React is not mentioned as a dev or peerDependencies.
Is this intentional?