### PR TITLE
tag recomputed actions

### DIFF
--- a/src/devTools.js
+++ b/src/devTools.js
@@ -60,6 +60,8 @@ function recomputeStates(reducer, committedState, stagedActions, skippedActions)
 
   for (let i = 0; i < stagedActions.length; i++) {
     const action = stagedActions[i];
+    
+    if (i !== stagedActions.length - 1) action._recomputed = true;
 
     const previousEntry = computedStates[i - 1];
     const previousState = previousEntry ? previousEntry.state : committedState;


### PR DESCRIPTION
I'm writing a store enhancer and had lots of bugs when working with devtools and my own store enhancer. This is the only way I could prevent recomputed actions from the devtools to mess with my store enhancer.

I also tried including my store enhancer first and devtools first. Neither option worked fine.

I hope this is a good way to handle these kinds of issues, if not, please let me know a different way to do this.