### PR TITLE
fix(DevTools, LogMonitor): prevent LogMonitor to render once as visible state

### DIFF
--- a/src/createDevTools.js
+++ b/src/createDevTools.js
@@ -10,9 +10,26 @@ export default function createDevTools(React) {
     ActionCreators
   )
   class DevTools extends Component {
+
+    static defaultProps = {
+      visibleOnLoad: true
+    };
+
+    componentWillMount() {
+      const monitorState = {
+        ...this.props.monitorState,
+        isVisible: this.props.visibleOnLoad
+      };
+      this.props.setMonitorState(monitorState);
+    }
+
     render() {
+      const monitorState = {
+        ...this.props.monitorState,
+        isVisible: this.props.visibleOnLoad
+      };
       const { monitor: Monitor } = this.props;
-      return <Monitor {...this.props} />;
+      return <Monitor {...this.props} monitorState={monitorState} />;
     }
   }
 

--- a/src/react/LogMonitor.js
+++ b/src/react/LogMonitor.js
@@ -53,15 +53,13 @@ export default class LogMonitor extends Component {
     toggleAction: PropTypes.func.isRequired,
     jumpToState: PropTypes.func.isRequired,
     setMonitorState: PropTypes.func.isRequired,
-    select: PropTypes.func.isRequired,
-    visibleOnLoad: PropTypes.bool
+    select: PropTypes.func.isRequired
   };
 
   static defaultProps = {
     select: (state) => state,
     monitorState: { isVisible: true },
-    theme: 'nicinabox',
-    visibleOnLoad: true
+    theme: 'nicinabox'
   };
 
   componentWillReceiveProps(nextProps) {
@@ -91,15 +89,6 @@ export default class LogMonitor extends Component {
       node.scrollTop = scrollHeight - offsetHeight;
       this.scrollDown = false;
     }
-  }
-
-  componentWillMount() {
-    let visibleOnLoad = this.props.visibleOnLoad;
-    const { monitorState } = this.props;
-    this.props.setMonitorState({
-      ...monitorState,
-      isVisible: visibleOnLoad
-    });
   }
 
   handleRollback() {


### PR DESCRIPTION
I noticed that LogMonitor is rendered once, because `isVisible` is set to true in the initial state.
see https://github.com/gaearon/redux-devtools/blob/master/src/devTools.js#L89

In the LogMonitor the `isVisible` state was updated, but that will only affect the second render cycle. This is an issue in case you try to create a universal/isomorphic application with the same template.

<img width="805" alt="screen shot 2015-09-20 at 19 54 08" src="https://cloud.githubusercontent.com/assets/223045/9982142/402e8d0e-5fd2-11e5-8cd1-5a625e333f61.png">

I propose to fix it by updating the props optimistically. As an alternative we could do this case inside the LogMonitor. Let me know what you think :smile: 