### PR TITLE
Do not recompute states unless necessary

### DIFF
--- a/test/devTools.spec.js
+++ b/test/devTools.spec.js
@@ -212,4 +212,35 @@ describe('devTools', () => {
     storeWithBug.dispatch({ type: 'SET_UNDEFINED' });
     expect(storeWithBug.getState()).toBe(2);
   });
+
+  it('should not recompute states on every action', () => {
+    let reducerCalls = 0;
+    let monitoredStore = devTools()(createStore)(() => reducerCalls++);
+    expect(reducerCalls).toBe(1);
+    monitoredStore.dispatch({ type: 'INCREMENT' });
+    monitoredStore.dispatch({ type: 'INCREMENT' });
+    monitoredStore.dispatch({ type: 'INCREMENT' });
+    expect(reducerCalls).toBe(4);
+  });
+
+  it('should not recompute states when jumping to state', () => {
+    let reducerCalls = 0;
+    let monitoredStore = devTools()(createStore)(() => reducerCalls++);
+    let monitoredDevToolsStore = monitoredStore.devToolsStore;
+
+    expect(reducerCalls).toBe(1);
+    monitoredStore.dispatch({ type: 'INCREMENT' });
+    monitoredStore.dispatch({ type: 'INCREMENT' });
+    monitoredStore.dispatch({ type: 'INCREMENT' });
+    expect(reducerCalls).toBe(4);
+
+    monitoredDevToolsStore.dispatch(ActionCreators.jumpToState(0));
+    expect(reducerCalls).toBe(4);
+
+    monitoredDevToolsStore.dispatch(ActionCreators.jumpToState(1));
+    expect(reducerCalls).toBe(4);
+
+    monitoredDevToolsStore.dispatch(ActionCreators.jumpToState(3));
+    expect(reducerCalls).toBe(4);
+  });
 });


### PR DESCRIPTION
This is a first stab at optimizing DevTools.
With this change, regular app actions don't cause DevTools to recompute every state. (https://github.com/gaearon/redux-devtools/issues/81)

Pressing DevTools buttons (e.g. Commit / Rollback / toggling actions) will still cause recomputations, but I don't see it as a big issue.