### PR TITLE
Use read-dom for findDOMNode calls in LogMonitor

### DIFF
--- a/src/react/LogMonitor.js
+++ b/src/react/LogMonitor.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, findDOMNode, Component } from 'react';
+import React, { PropTypes, Component } from 'react';
+import { findDOMNode } from 'react-dom';
 import LogMonitorEntry from './LogMonitorEntry';
 import LogMonitorButton from './LogMonitorButton';
 import * as themes from './themes';


### PR DESCRIPTION
Tiny change an makes the current build not throw red warnings when used in React 14-rc1.

Tests still pass locally.