### PR TITLE
Create UMD Build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 .DS_Store
 lib
 coverage
+dist

--- a/package.json
+++ b/package.json
@@ -5,7 +5,12 @@
   "main": "lib/index.js",
   "scripts": {
     "clean": "rimraf lib",
-    "build": "babel src --out-dir lib",
+    "build:lib": "babel src --out-dir lib",
+    "build:umd": "webpack src/index.js dist/redux-devtools.js --config webpack.config.development.js",
+    "build:umd:min": "webpack src/index.js dist/redux-devtools.min.js --config webpack.config.production.js",
+    "build:umd:react": "webpack src/react/index.js dist/redux-devtools.react.js --config webpack.config.development.js",
+    "build:umd:react:min": "webpack src/react/index.js dist/redux-devtools.react.min.js --config webpack.config.production.js",
+    "build": "npm run build:lib && npm run build:umd && npm run build:umd:min && npm run build:umd:react && npm run build:umd:react:min",
     "lint": "eslint src test examples",
     "test": "NODE_ENV=test mocha --compilers js:babel/register --recursive",
     "test:watch": "NODE_ENV=test mocha --compilers js:babel/register --recursive --watch",

--- a/src/createDevTools.js
+++ b/src/createDevTools.js
@@ -1,9 +1,8 @@
-import createAll from 'react-redux/lib/components/createAll';
+import { connect } from 'react-redux';
 import { ActionCreators } from './devTools';
 
 export default function createDevTools(React) {
   const { PropTypes, Component } = React;
-  const { connect } = createAll(React);
 
   @connect(
     state => state,

--- a/webpack.config.base.js
+++ b/webpack.config.base.js
@@ -1,0 +1,45 @@
+'use strict';
+
+var webpack = require('webpack');
+
+var reactExternal = {
+  root: 'React',
+  commonjs2: 'react',
+  commonjs: 'react',
+  amd: 'react'
+};
+
+var reactReduxExternal = {
+  root: 'ReactRedux',
+  commonjs2: 'react-redux',
+  commonjs: 'react-redux',
+  amd: 'react-redux'
+};
+
+var reduxExternal = {
+  root: 'Redux',
+  commonjs2: 'redux',
+  commonjs: 'redux',
+  amd: 'redux'
+};
+
+module.exports = {
+  externals: {
+    'react': reactExternal,
+    'react-native': reactExternal,
+    'react-redux': reactReduxExternal,
+    'redux': reduxExternal
+  },
+  module: {
+    loaders: [
+      { test: /\.js$/, loaders: ['babel-loader'], exclude: /node_modules/ }
+    ]
+  },
+  output: {
+    library: 'ReduxDevTools',
+    libraryTarget: 'umd'
+  },
+  resolve: {
+    extensions: ['', '.js']
+  }
+};

--- a/webpack.config.development.js
+++ b/webpack.config.development.js
@@ -1,0 +1,14 @@
+'use strict';
+
+var webpack = require('webpack');
+var baseConfig = require('./webpack.config.base');
+
+var config = Object.create(baseConfig);
+config.plugins = [
+  new webpack.optimize.OccurenceOrderPlugin(),
+  new webpack.DefinePlugin({
+    'process.env.NODE_ENV': JSON.stringify('development')
+  })
+];
+
+module.exports = config;

--- a/webpack.config.production.js
+++ b/webpack.config.production.js
@@ -1,0 +1,20 @@
+'use strict';
+
+var webpack = require('webpack');
+var baseConfig = require('./webpack.config.base');
+
+var config = Object.create(baseConfig);
+config.plugins = [
+  new webpack.optimize.OccurenceOrderPlugin(),
+  new webpack.DefinePlugin({
+    'process.env.NODE_ENV': JSON.stringify('production')
+  }),
+  new webpack.optimize.UglifyJsPlugin({
+    compressor: {
+      screw_ie8: true,
+      warnings: false
+    }
+  })
+];
+
+module.exports = config;


### PR DESCRIPTION
I have 2 notes about this change:
* I separated the build to 2 packages: the logical parts and the react components. If there's a better way to put everything in one file please let me know.
* I used "connect" instead of "createAll" from react-redux, it was easier this way to regard react-redux as an external library. I didn't know how to do it otherwise, so again, if there's a better way let me know.

I tested the result with my RequireJS project and it works great.
I also tested the regular build (from lib folder) to make sure that the modified react-redux import didn't break anything.