### PR TITLE
Bump react-json-tree dependency to 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "redux": "^2.0.0 || ^3.0.0"
   },
   "dependencies": {
-    "react-json-tree": "^0.1.9",
+    "react-json-tree": "^0.2.0",
     "react-mixin": "^1.7.0",
     "react-redux": "^3.0.0",
     "redux": "^2.0.0 || ^3.0.0"


### PR DESCRIPTION
Version 0.2.0 support React 0.13.1 and 0.13.2 instead of requiring at least 0.13.3.