### PR TITLE
Update for react@0.14.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,9 +43,9 @@
     "jsdom": "^6.5.1",
     "mocha": "^2.2.5",
     "mocha-jsdom": "^1.0.0",
-    "react": "^0.14.0-rc1",
-    "react-addons-test-utils": "^0.14.0-rc1",
-    "react-dom": "^0.14.0-rc1",
+    "react": "^0.14.0",
+    "react-addons-test-utils": "^0.14.0",
+    "react-dom": "0.14.0",
     "rimraf": "^2.3.4",
     "webpack": "^1.11.0"
   },

--- a/src/react/LogMonitor.js
+++ b/src/react/LogMonitor.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, findDOMNode, Component } from 'react';
+import React, { PropTypes,  Component } from 'react';
+import { findDOMNode } from 'react-dom';
 import LogMonitorEntry from './LogMonitorEntry';
 import LogMonitorButton from './LogMonitorButton';
 import * as themes from './themes';

--- a/src/react/LogMonitor.js
+++ b/src/react/LogMonitor.js
@@ -1,4 +1,4 @@
-import React, { PropTypes,  Component } from 'react';
+import React, { PropTypes, Component } from 'react';
 import { findDOMNode } from 'react-dom';
 import LogMonitorEntry from './LogMonitorEntry';
 import LogMonitorButton from './LogMonitorButton';


### PR DESCRIPTION
Fixed this: React.findDOMNode is deprecated. Please use ReactDOM.findDOMNode from require('react-dom') instead in LogMonitor