### PR TITLE
Warn and do not attempt to render if store not instrumented

### DIFF
--- a/src/createDevTools.js
+++ b/src/createDevTools.js
@@ -24,14 +24,32 @@ export default function createDevTools(children) {
 
     constructor(props, context) {
       super(props, context);
+
+      if (!props.store && !context.store) {
+        console.error(
+`DevTools cannot render because no Redux store was injected via \
+props or <Provide>`);
+        return;
+      }
+
       if (context.store) {
         this.liftedStore = context.store.liftedStore;
       } else {
         this.liftedStore = props.store.liftedStore;
       }
+
+      if (!this.liftedStore) {
+        console.error(
+`DevTools cannot render because the store not been instrumented \
+with DevTools.instrument()`);
+      }
     }
 
     render() {
+      if (!this.liftedStore) {
+        return null;
+      }
+
       return (
         <ConnectedMonitor {...monitorProps}
                           store={this.liftedStore} />
@@ -39,4 +57,3 @@ export default function createDevTools(children) {
     }
   };
 }
-


### PR DESCRIPTION
Very confusing error messages were produced if the
container component returned by createDevTools()
was constructed without a store being injected or
if the store had not been instrumented with
DevTools.instrument()

Add warnings for both of these cases and avoid console error
spam by short circuiting rendering of the devtools if they
have not been setup correctly.

Fixes #179