### PR TITLE
Fix class property in todomvc example

### DIFF
--- a/examples/todomvc/components/Footer.js
+++ b/examples/todomvc/components/Footer.js
@@ -15,7 +15,7 @@ export default class Footer extends Component {
     filter: PropTypes.string.isRequired,
     onClearMarked: PropTypes.func.isRequired,
     onShow: PropTypes.func.isRequired
-  }
+  };
 
   render() {
     return (


### PR DESCRIPTION
Fix error caused by missing semicolon in the class property declaration.

Relevant part of the ES proposal: https://github.com/jeffmo/es-class-fields-and-static-properties#145-class-definitions

Full error message:

> ERROR in ./components/Footer.js
Module build failed: SyntaxError: redux-devtools/examples/todomvc/components/Footer.js: A semicolon is required after a class property (18:3)