### PR TITLE
Add error on undefined action type

### DIFF
--- a/src/instrument.js
+++ b/src/instrument.js
@@ -16,6 +16,12 @@ export const ActionTypes = {
  */
 export const ActionCreators = {
   performAction(action) {
+    if (typeof action.type === 'undefined') {
+      throw new Error(
+        'Actions may not have an undefined "type" property. ' +
+        'Have you misspelled a constant?'
+      );
+    }
     return { type: ActionTypes.PERFORM_ACTION, action, timestamp: Date.now() };
   },
 

--- a/test/instrument.spec.js
+++ b/test/instrument.spec.js
@@ -176,6 +176,14 @@ describe('instrument', () => {
     spy.restore();
   });
 
+  it('should catch invalid action type', () => {
+    expect(() => {
+      store.dispatch({ type: undefined });
+    }).toThrow(
+      /Actions may not have an undefined/
+    );
+  });
+
   it('should return the last non-undefined state from getState', () => {
     let storeWithBug = instrument()(createStore)(counterWithBug);
     storeWithBug.dispatch({ type: 'INCREMENT' });


### PR DESCRIPTION
First, thanks for a great development tool! 

I like the helpful errors in Redux, e.g. for undefined `action.type`. Of course you should have unit test catching this, but it would be nice if `redux-devtools` also had this message in case the action type is `undefined`. 

I ported the behaviour from here:
https://github.com/rackt/redux/blob/5b94a18f560eff60ce37ae01d1b16387bcfb8e3a/src/createStore.js#L110

Let me know what you think. : )

