### PR TITLE
Show error message, not just a stack trace

### DIFF
--- a/src/instrument.js
+++ b/src/instrument.js
@@ -77,7 +77,7 @@ function computeNextEntry(reducer, action, state, error) {
       // In Chrome, rethrowing provides better source map support
       setTimeout(() => { throw err; });
     } else {
-      console.error(err.stack || err);
+      console.error(err);
     }
   }
 

--- a/test/instrument.spec.js
+++ b/test/instrument.spec.js
@@ -169,7 +169,7 @@ describe('instrument', () => {
     expect(computedStates[3].error).toMatch(
       /Interrupted by an error up the chain/
     );
-    expect(spy.calls[0].arguments[0]).toMatch(
+    expect(spy.calls[0].arguments[0].toString()).toMatch(
       /ReferenceError/
     );
 


### PR DESCRIPTION
Before:

![](http://wow.sapegin.me/3f1F2I2Z0W23/Image%202016-02-04%20at%203.38.17%20PM.png)

After:

![](http://wow.sapegin.me/2p3P2f1X1W11/Image%202016-02-04%20at%203.38.03%20PM.png)
