### PR TITLE
add maxAge option

### DIFF
--- a/src/createDevTools.js
+++ b/src/createDevTools.js
@@ -7,9 +7,6 @@ export default function createDevTools(children) {
   const monitorProps = monitorElement.props;
   const Monitor = monitorElement.type;
   const ConnectedMonitor = connect(state => state)(Monitor);
-  const enhancer = instrument((state, action) =>
-    Monitor.update(monitorProps, state, action)
-  );
 
   return class DevTools extends Component {
     static contextTypes = {
@@ -20,7 +17,10 @@ export default function createDevTools(children) {
       store: PropTypes.object
     };
 
-    static instrument = () => enhancer;
+    static instrument = (options) => instrument(
+      (state, action) => Monitor.update(monitorProps, state, action),
+      options
+    );
 
     constructor(props, context) {
       super(props, context);

--- a/src/instrument.js
+++ b/src/instrument.js
@@ -172,7 +172,7 @@ function liftReducerWith(reducer, initialCommittedState, monitorReducer, options
 
       for (let i = 0; i < idsToDelete.length; i++) {
         if (computedStates[i + 1].error) {
-          // Stop if error is found. Commit only up to error.
+          // Stop if error is found. Commit actions up to error.
           excess = i;
           idsToDelete = stagedActionIds.slice(1, excess + 1);
           break;

--- a/src/instrument.js
+++ b/src/instrument.js
@@ -235,15 +235,18 @@ function liftReducerWith(reducer, initialCommittedState, monitorReducer, options
         break;
       }
       case ActionTypes.PERFORM_ACTION: {
-        if (options.maxAge && stagedActionIds.length === options.maxAge) {
+        if (
+          options.maxAge &&
+          stagedActionIds.length === options.maxAge &&
+          !computedStates[1].error
+        ) {
           // If maxAge has been reached, auto-commit earliest non-@@INIT action.
           delete actionsById[stagedActionIds[1]];
           skippedActionIds = skippedActionIds.filter(id => id !== stagedActionIds[1]);
           stagedActionIds = [0].concat(stagedActionIds.slice(2));
           committedState = computedStates[1].state;
           computedStates = computedStates.slice(1);
-        }
-        if (currentStateIndex === stagedActionIds.length - 1) {
+        } else if (currentStateIndex === stagedActionIds.length - 1) {
           currentStateIndex++;
         }
         const actionId = nextActionId++;

--- a/src/instrument.js
+++ b/src/instrument.js
@@ -238,7 +238,7 @@ function liftReducerWith(reducer, initialCommittedState, monitorReducer, options
         if (options.maxAge && stagedActionIds.length === options.maxAge) {
           // If maxAge has been reached, remove oldest action.
           delete actionsById[stagedActionIds[1]];
-          skippedActionIds = skippedActionIds.filter(id => id !== stagedActionIds[0]);
+          skippedActionIds = skippedActionIds.filter(id => id !== stagedActionIds[1]);
           stagedActionIds = [0].concat(stagedActionIds.slice(2));
           committedState = computedStates[1].state;
           computedStates = computedStates.slice(1);

--- a/src/instrument.js
+++ b/src/instrument.js
@@ -165,8 +165,9 @@ function liftReducerWith(reducer, initialCommittedState, monitorReducer, options
       computedStates
     } = liftedState;
 
-    function commitExcessActions(excess) {
-      // If maxAge has been exceeded, auto-commit excess.
+    function commitExcessActions(n) {
+      // Auto-commits n-number of excess actions.
+      let excess = n;
       let idsToDelete = stagedActionIds.slice(1, excess + 1);
 
       for (let i = 0; i < idsToDelete.length; i++) {

--- a/src/instrument.js
+++ b/src/instrument.js
@@ -236,10 +236,10 @@ function liftReducerWith(reducer, initialCommittedState, monitorReducer, options
       }
       case ActionTypes.PERFORM_ACTION: {
         if (options.maxAge && stagedActionIds.length === options.maxAge) {
-          // If maxAge has been reached, remove oldest action
-          delete actionsById[stagedActionIds[0]];
+          // If maxAge has been reached, remove oldest action.
+          delete actionsById[stagedActionIds[1]];
           skippedActionIds = skippedActionIds.filter(id => id !== stagedActionIds[0]);
-          stagedActionIds = stagedActionIds.slice(1);
+          stagedActionIds = [0].concat(stagedActionIds.slice(2));
           committedState = computedStates[1].state;
           computedStates = computedStates.slice(1);
         }

--- a/src/instrument.js
+++ b/src/instrument.js
@@ -347,9 +347,7 @@ function unliftStore(liftedStore, liftReducer) {
 /**
  * Redux instrumentation store enhancer.
  */
-export default function instrument(monitorReducer, options = {}) {
-  if (!monitorReducer) { monitorReducer = () => null; }
-
+export default function instrument(monitorReducer = () => null, options = {}) {
   return createStore => (reducer, initialState, enhancer) => {
 
     function liftReducer(r) {

--- a/src/instrument.js
+++ b/src/instrument.js
@@ -236,7 +236,7 @@ function liftReducerWith(reducer, initialCommittedState, monitorReducer, options
       }
       case ActionTypes.PERFORM_ACTION: {
         if (options.maxAge && stagedActionIds.length === options.maxAge) {
-          // If maxAge has been reached, remove oldest action.
+          // If maxAge has been reached, auto-commit earliest non-@@INIT action.
           delete actionsById[stagedActionIds[1]];
           skippedActionIds = skippedActionIds.filter(id => id !== stagedActionIds[1]);
           stagedActionIds = [0].concat(stagedActionIds.slice(2));

--- a/test/instrument.spec.js
+++ b/test/instrument.spec.js
@@ -411,24 +411,24 @@ describe('instrument', () => {
       // currentStateIndex continues to increment while non-committed action causes error
       expect(liftedStoreState.currentStateIndex).toBe(5);
       expect(currentComputedState.state).toBe(3);
-      expect(currentComputedState.error).toExist;
+      expect(currentComputedState.error).toExist();
 
       configuredStore.replaceReducer(counterWithAnotherBug);
       liftedStoreState = configuredLiftedStore.getState();
       currentComputedState = liftedStoreState.computedStates[liftedStoreState.currentStateIndex];
-      // currentStateIndex adjusts correctly when multiple actions are committed
+      // currentStateIndex adjusts accordingly when multiple actions are committed
       expect(liftedStoreState.currentStateIndex).toBe(2);
       expect(currentComputedState.state).toBe(0);
-      expect(currentComputedState.error).toExist;
+      expect(currentComputedState.error).toExist();
 
       configuredLiftedStore.dispatch(ActionCreators.jumpToState(0));
       configuredStore.replaceReducer(counter);
       liftedStoreState = configuredLiftedStore.getState();
-      // currentStateIndex stays at 0 as actions are committed
+      // currentStateIndex doesn't go below 0
       currentComputedState = liftedStoreState.computedStates[liftedStoreState.currentStateIndex];
       expect(liftedStoreState.currentStateIndex).toBe(0);
       expect(currentComputedState.state).toBe(0);
-      expect(currentComputedState.error).toNotExist;
+      expect(currentComputedState.error).toNotExist();
 
       spy.restore();
     });

--- a/test/instrument.spec.js
+++ b/test/instrument.spec.js
@@ -384,7 +384,6 @@ describe('instrument', () => {
     });
 
     it('should update currentStateIndex when auto-committing', () => {
-      let spy = spyOn(console, 'error');
       let liftedStoreState;
       let currentComputedState;
 
@@ -399,8 +398,6 @@ describe('instrument', () => {
       currentComputedState = liftedStoreState.computedStates[liftedStoreState.currentStateIndex];
       expect(liftedStoreState.currentStateIndex).toBe(2);
       expect(currentComputedState.state).toBe(3);
-
-      spy.restore();
     });
 
     it('should continue to increment currentStateIndex while error blocks commit', () => {

--- a/test/instrument.spec.js
+++ b/test/instrument.spec.js
@@ -385,7 +385,8 @@ describe('instrument', () => {
 
     it('should update currentStateIndex when auto-committing', () => {
       let spy = spyOn(console, 'error');
-      let liftedStoreState, currentComputedState;
+      let liftedStoreState;
+      let currentComputedState;
 
       configuredStore.dispatch({ type: 'INCREMENT' });
       configuredStore.dispatch({ type: 'INCREMENT' });

--- a/test/instrument.spec.js
+++ b/test/instrument.spec.js
@@ -323,7 +323,7 @@ describe('instrument', () => {
       expect(liftedStoreState.committedState).toBe(undefined);
       expect(liftedStoreState.stagedActionIds).toInclude(1);
 
-      // Triggers auto-commit.
+      // Trigger auto-commit.
       configuredStore.dispatch({ type: 'INCREMENT' });
       liftedStoreState = configuredLiftedStore.getState();
 
@@ -372,11 +372,11 @@ describe('instrument', () => {
       storeWithBug.dispatch({ type: 'DECREMENT' });
       expect(liftedStoreWithBug.getState().stagedActionIds.length).toBe(7);
 
-      // should auto-commit only 2 non-error actions
+      // Auto-commit 2 actions by "fixing" reducer bug, but introducing another.
       storeWithBug.replaceReducer(counterWithAnotherBug);
       expect(liftedStoreWithBug.getState().stagedActionIds.length).toBe(5);
 
-      // should auto-commit down to 3 actions
+      // Auto-commit 2 more actions by "fixing" other reducer bug.
       storeWithBug.replaceReducer(counter);
       expect(liftedStoreWithBug.getState().stagedActionIds.length).toBe(3);
 
@@ -392,7 +392,7 @@ describe('instrument', () => {
       liftedStoreState = configuredLiftedStore.getState();
       expect(liftedStoreState.currentStateIndex).toBe(2);
 
-      // currentStateIndex should stay at 2 as actions are committed
+      // currentStateIndex should stay at 2 as actions are committed.
       configuredStore.dispatch({ type: 'INCREMENT' });
       liftedStoreState = configuredLiftedStore.getState();
       currentComputedState = liftedStoreState.computedStates[liftedStoreState.currentStateIndex];

--- a/test/instrument.spec.js
+++ b/test/instrument.spec.js
@@ -300,7 +300,7 @@ describe('instrument', () => {
     let configuredLiftedStore;
 
     beforeEach(() => {
-      configuredStore = createStore(counter, instrument(null, { maxAge: 2 }));
+      configuredStore = createStore(counter, instrument(undefined, { maxAge: 2 }));
       configuredLiftedStore = configuredStore.liftedStore;
     });
 


### PR DESCRIPTION
- adds `options` parameter to instrument. Only `maxAge` property is used currently but could conceivably be used for other options.
- removes oldest actions once maxAge is reached
- should take care of [memory issues](https://github.com/gaearon/redux-devtools-log-monitor/issues/17) caused by high-frequency actions

Usage:

```js
DevTools.instrument({ maxAge: 30 });
```