### PR TITLE
Consecutive toggle

### DIFF
--- a/src/instrument.js
+++ b/src/instrument.js
@@ -1,4 +1,5 @@
 import difference from 'lodash/difference';
+import union from 'lodash/union';
 
 export const ActionTypes = {
   PERFORM_ACTION: 'PERFORM_ACTION',
@@ -7,6 +8,7 @@ export const ActionTypes = {
   COMMIT: 'COMMIT',
   SWEEP: 'SWEEP',
   TOGGLE_ACTION: 'TOGGLE_ACTION',
+  SET_ACTIONS_ACTIVE: 'SET_ACTIONS_ACTIVE',
   JUMP_TO_STATE: 'JUMP_TO_STATE',
   IMPORT_STATE: 'IMPORT_STATE'
 };
@@ -43,6 +45,10 @@ export const ActionCreators = {
 
   toggleAction(id) {
     return { type: ActionTypes.TOGGLE_ACTION, id };
+  },
+
+  setActionsActive(start, end, active=true) {
+    return { type: ActionTypes.SET_ACTIONS_ACTIVE, start, end, active };
   },
 
   jumpToState(index) {
@@ -217,6 +223,22 @@ function liftReducerWith(reducer, initialCommittedState, monitorReducer) {
         }
         // Optimization: we know history before this action hasn't changed
         minInvalidatedStateIndex = stagedActionIds.indexOf(actionId);
+        break;
+      }
+      case ActionTypes.SET_ACTIONS_ACTIVE: {
+        // Toggle whether an action with given ID is skipped.
+        // Being skipped means it is a no-op during the computation.
+        const { start, end, active } = liftedAction;
+        const actionIds = [];
+        for (let i = start; i < end; i++) actionIds.push(i);
+        if (active) {
+          skippedActionIds = difference(skippedActionIds, actionIds);
+        } else {
+          skippedActionIds = union(skippedActionIds, actionIds);
+        }
+
+        // Optimization: we know history before this action hasn't changed
+        minInvalidatedStateIndex = stagedActionIds.indexOf(start);
         break;
       }
       case ActionTypes.JUMP_TO_STATE: {

--- a/test/instrument.spec.js
+++ b/test/instrument.spec.js
@@ -100,6 +100,23 @@ describe('instrument', () => {
     expect(store.getState()).toBe(1);
   });
 
+  it('should set multiple action skip', () => {
+    // actionId 0 = @@INIT
+    store.dispatch({ type: 'INCREMENT' });
+    store.dispatch({ type: 'INCREMENT' });
+    store.dispatch({ type: 'INCREMENT' });
+    expect(store.getState()).toBe(3);
+
+    liftedStore.dispatch(ActionCreators.setActionsActive(1, 3, false));
+    expect(store.getState()).toBe(1);
+
+    liftedStore.dispatch(ActionCreators.setActionsActive(0, 2, true));
+    expect(store.getState()).toBe(2);
+
+    liftedStore.dispatch(ActionCreators.setActionsActive(0, 1, true));
+    expect(store.getState()).toBe(2);
+  });
+
   it('should sweep disabled actions', () => {
     // actionId 0 = @@INIT
     store.dispatch({ type: 'INCREMENT' });


### PR DESCRIPTION
Added SET_ACTIONS_ACTIVE action for ability to set multiple actions between start and end indices to be active or skipped. This is needed to allow log monitor to toggle multiple actions at once via `shift+click`.