### PR TITLE
fix regexp to extract debug session name

### DIFF
--- a/docs/Walkthrough.md
+++ b/docs/Walkthrough.md
@@ -121,7 +121,7 @@ const enhancer = compose(
 function getDebugSessionKey() {
   // You can write custom logic here!
   // By default we try to read the key from ?debug_session=<key> in the address bar
-  const matches = window.location.href.match(/[?&]debug_session=([^&]+)\b/);
+  const matches = window.location.href.match(/[?&]debug_session=([^&#]+)\b/);
   return (matches && matches.length > 0)? matches[1] : null;
 }
 

--- a/examples/counter/src/store/configureStore.dev.js
+++ b/examples/counter/src/store/configureStore.dev.js
@@ -9,7 +9,7 @@ const enhancer = compose(
   DevTools.instrument(),
   persistState(
     window.location.href.match(
-      /[?&]debug_session=([^&]+)\b/
+      /[?&]debug_session=([^&#]+)\b/
     )
   )
 );

--- a/examples/todomvc/store/configureStore.dev.js
+++ b/examples/todomvc/store/configureStore.dev.js
@@ -7,7 +7,7 @@ const enhancer = compose(
   DevTools.instrument(),
   persistState(
     window.location.href.match(
-      /[?&]debug_session=([^&]+)\b/
+      /[?&]debug_session=([^&#]+)\b/
     )
   )
 );


### PR DESCRIPTION
Extracting session name did not work when using url containing a hash

 ( For example when using hash history )

See #https://github.com/zalmoxisus/redux-devtools-extension/pull/59