### PR TITLE
Add defaultIsVisible to walkthrough docs

### DIFF
--- a/docs/Walkthrough.md
+++ b/docs/Walkthrough.md
@@ -45,8 +45,10 @@ const DevTools = createDevTools(
   // Monitors are individually adjustable with props.
   // Consult their repositories to learn about those props.
   // Here, we put LogMonitor inside a DockMonitor.
+  // Note: DockMonitor is visible by default.
   <DockMonitor toggleVisibilityKey='ctrl-h'
-               changePositionKey='ctrl-q'>
+               changePositionKey='ctrl-q'
+               defaultIsVisible={true}>
     <LogMonitor theme='tomorrow' />
   </DockMonitor>
 );


### PR DESCRIPTION
## Overview

This PR adds documentation for hiding the DockMonitor on page load.

## Notes

- The README previously contained documentation on the `visibleOnLoad` property under "features" (see [here](https://github.com/gaearon/redux-devtools/pull/75/files)). But that prop and documentation has been removed. 

- While looking for a replacement, I found  `defaultIsVisible` in https://github.com/gaearon/redux-devtools/issues/163 and confirmed that it's still in use.

- I don't think this belongs under features in the README as before. Instead I added it to the usage section of the walkthrough, where it's likely to have the highest visibility.