### PR TITLE
Provide information that action is being replayed

### DIFF
--- a/docs/Walkthrough.md
+++ b/docs/Walkthrough.md
@@ -368,6 +368,8 @@ Note that there are no useful props you can pass to the `DevTools` component oth
 
 * **It is important that `DevTools.instrument()` store enhancer should be added to your middleware stack *after* `applyMiddleware` in the `compose`d functions, as `applyMiddleware` is potentially asynchronous.** Otherwise, DevTools won’t see the raw actions emitted by asynchronous middleware such as [redux-promise](https://github.com/acdlite/redux-promise) or [redux-thunk](https://github.com/gaearon/redux-thunk).
 
+* **Are you a library author**? If you're building a Store Enhancer you might find handy to know which actions have been dispatched regularly and which have been replayed. `redux-devtools` is calling reducer with third argument. The argument is a boolean identifying that Action has been replayed.
+
 ### What Next?
 
 Now that you see the DevTools, you might want to learn what those buttons mean and how to use them. This usually depends on the monitor. You can begin by exploring the [LogMonitor](https://github.com/gaearon/redux-devtools-log-monitor) and [DockMonitor](https://github.com/gaearon/redux-devtools-dock-monitor) documentation, as they are the default monitors we suggest to use together. When you’re comfortable using them, you may want to create your own monitor for more exotic purposes, such as a [chart](https://github.com/romseguy/redux-devtools-chart-monitor) or a [diff](https://github.com/whetstone/redux-devtools-diff-monitor) monitor. Don’t forget to send a PR to feature your monitor at the front page!

--- a/src/instrument.js
+++ b/src/instrument.js
@@ -70,7 +70,7 @@ function computeNextEntry(reducer, action, state, error, replaying) {
   let nextState = state;
   let nextError;
   try {
-    nextState = reducer(state, action, replaying);
+    nextState = reducer(state, { ...action, replaying });
   } catch (err) {
     nextError = err.toString();
     if (typeof window === 'object' && typeof window.chrome !== 'undefined') {

--- a/test/instrument.spec.js
+++ b/test/instrument.spec.js
@@ -362,6 +362,9 @@ describe('instrument', () => {
     const INIT_ACTION = { type: '@@INIT' };
     const TESTING_APP_STATE = 42;
 
+    const buildTestingAction = replaying => ({ ...TESTING_ACTION, replaying });
+    const buildInitAction = replaying => ({ ...INIT_ACTION, replaying });
+
     let spiedEmptyReducer;
     let replayingStore;
     let liftedReplayingStore;
@@ -374,53 +377,53 @@ describe('instrument', () => {
       liftedReplayingStore = replayingStore.liftedStore;
     });
 
-    it('should provide falsy replaying argument when plain action is dispatched', () => {
+    it('should provide falsy replaying flag when plain action is dispatched', () => {
       replayingStore.dispatch(TESTING_ACTION);
       expect(spiedEmptyReducer).toHaveBeenCalled();
-      expect(spiedEmptyReducer.calls[1].arguments).toEqual([TESTING_APP_STATE, TESTING_ACTION, false]);
+      expect(spiedEmptyReducer.calls[1].arguments).toEqual([TESTING_APP_STATE, buildTestingAction(false)]);
     });
 
-    it('should provide falsy replaying argument when PERFORM_ACTION is dispatched', () => {
+    it('should provide falsy replaying flag when PERFORM_ACTION is dispatched', () => {
       replayingStore.dispatch(TESTING_ACTION);
       liftedReplayingStore.dispatch(ActionCreators.performAction(TESTING_ACTION));
-      expect(spiedEmptyReducer.calls[1].arguments).toEqual([TESTING_APP_STATE, TESTING_ACTION, false]);
+      expect(spiedEmptyReducer.calls[1].arguments).toEqual([TESTING_APP_STATE, buildTestingAction(false)]);
     });
 
-    it('should provide truthy replaying argument for init action which follows rollback', () => {
+    it('should provide truthy replaying flag for init action which follows rollback', () => {
       replayingStore.dispatch(TESTING_ACTION);
       liftedReplayingStore.dispatch(ActionCreators.rollback());
-      expect(spiedEmptyReducer.calls[2].arguments).toEqual([undefined, INIT_ACTION, true]);
+      expect(spiedEmptyReducer.calls[2].arguments).toEqual([undefined, buildInitAction(true)]);
     });
 
-    it('should provide truthy replaying argument for init action which follows reset', () => {
+    it('should provide truthy replaying flag for init action which follows reset', () => {
       replayingStore.dispatch(TESTING_ACTION);
       liftedReplayingStore.dispatch(ActionCreators.reset());
-      expect(spiedEmptyReducer.calls[2].arguments).toEqual([undefined, INIT_ACTION, true]);
+      expect(spiedEmptyReducer.calls[2].arguments).toEqual([undefined, buildInitAction(true)]);
     });
 
-    it('should provide truthy replaying argument for init action which follows commit', () => {
+    it('should provide truthy replaying flag for init action which follows commit', () => {
       replayingStore.dispatch(TESTING_ACTION);
       liftedReplayingStore.dispatch(ActionCreators.commit());
-      expect(spiedEmptyReducer.calls[2].arguments).toEqual([42, INIT_ACTION, true]);
+      expect(spiedEmptyReducer.calls[2].arguments).toEqual([42, buildInitAction(true)]);
     });
 
-    it('should provide truthy replaying argument for all the actions after sweeping', () => {
+    it('should provide truthy replaying flag for all the actions after sweeping', () => {
       replayingStore.dispatch(TESTING_ACTION);
       liftedReplayingStore.dispatch(ActionCreators.sweep());
-      expect(spiedEmptyReducer.calls[2].arguments).toEqual([undefined, INIT_ACTION, true]);
-      expect(spiedEmptyReducer.calls[3].arguments).toEqual([TESTING_APP_STATE, TESTING_ACTION, true]);
+      expect(spiedEmptyReducer.calls[2].arguments).toEqual([undefined, buildInitAction(true)]);
+      expect(spiedEmptyReducer.calls[3].arguments).toEqual([TESTING_APP_STATE, buildTestingAction(true)]);
     });
 
-    it('after toggling, should provide truthy replaying argument for action which has not been toggled', () => {
+    it('after toggling, should provide truthy replaying flag for action which has not been toggled', () => {
       const NEXT_TESTING_ACTION = { type: 'NEXT_TESTING_ACTION' };
 
       replayingStore.dispatch(TESTING_ACTION);
       replayingStore.dispatch(NEXT_TESTING_ACTION);
       liftedReplayingStore.dispatch(ActionCreators.toggleAction(1));
-      expect(spiedEmptyReducer.calls[3].arguments).toEqual([TESTING_APP_STATE, NEXT_TESTING_ACTION, true]);
+      expect(spiedEmptyReducer.calls[3].arguments).toEqual([TESTING_APP_STATE, { ...NEXT_TESTING_ACTION, replaying: true }]);
     });
 
-    it('should provide truthy replaying argument for all the actions after importing state', () => {
+    it('should provide truthy replaying flag for all the actions after importing state', () => {
       replayingStore.dispatch(TESTING_ACTION);
       const exportedState = liftedReplayingStore.getState();
 
@@ -431,9 +434,9 @@ describe('instrument', () => {
       const importStore = createStore(spiedImportStoreReducer, instrument());
       importStore.liftedStore.dispatch(ActionCreators.importState(exportedState));
 
-      expect(spiedImportStoreReducer.calls[0].arguments).toEqual([undefined, INIT_ACTION, false]);
-      expect(spiedImportStoreReducer.calls[1].arguments).toEqual([undefined, INIT_ACTION, true]);
-      expect(spiedImportStoreReducer.calls[2].arguments).toEqual([TESTING_APP_STATE, TESTING_ACTION, true]);
+      expect(spiedImportStoreReducer.calls[0].arguments).toEqual([undefined, buildInitAction(false)]);
+      expect(spiedImportStoreReducer.calls[1].arguments).toEqual([undefined, buildInitAction(true)]);
+      expect(spiedImportStoreReducer.calls[2].arguments).toEqual([TESTING_APP_STATE, buildTestingAction(true)]);
     });
   });
 });


### PR DESCRIPTION
There are obviously some libraries which are trying to reduce side effects in Reducers (https://github.com/salsita/redux-side-effects, https://github.com/raisemarketplace/redux-loop), however we need to maintain purity of these Reducers - side effect execution is always deferred. This is easy to implement for classic Reducers but we would need to make it work for devtools time travel as well.

There is a workaround and it's basically the way redux-loop is doing that by [overriding `dispatch`](https://github.com/raisemarketplace/redux-loop/blob/master/modules/install.js#L38-L42) drawback of this solution is though that modified `dispatch` is not used for redux init action and this is for example problem for reproducing Elm architecture in Redux because in Elm architecture there might be side effects in the init function.

That's why we [re-wrote redux-side-effects](https://github.com/salsita/redux-side-effects/commit/875ddc6be25977619cf76d7d6b17bbbac98f6aa9#diff-b2037c95647bbd93515ca58460ccc012L75), however this introduces issue with timetravel because we don't have any way to find out when the action is being replayed and when not. [This comment](https://github.com/salsita/redux-side-effects/issues/14#issuecomment-204150958) describes it quite accurately.

This PR does solve the problem, we need to decide about proper way to implement it though because right now `replaying` flag is passed as third argument to reducer. The question is though, is that really sane? Can't it break some functionality of other people? Maybe it would be better to provide the information directly in the action itself.
