### PR TITLE
Support React >= 15 peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   },
   "peerDependencies": {
     "redux": "^3.0.0",
-    "react": "^0.14.0 || ^15.0.0-rc.1"
+    "react": "^0.14.0 || ^15.0.0"
   },
   "dependencies": {
     "lodash": "^4.2.0",


### PR DESCRIPTION
This semver range is breaking https://github.com/whetstone/redux-devtools-diff-monitor/pull/28. Can we get a React 15 version cut?