### PR TITLE
maxAge should throw error when < 2

### DIFF
--- a/src/instrument.js
+++ b/src/instrument.js
@@ -411,6 +411,15 @@ function unliftStore(liftedStore, liftReducer) {
  * Redux instrumentation store enhancer.
  */
 export default function instrument(monitorReducer = () => null, options = {}) {
+  /* eslint-disable no-eq-null */
+  if (options.maxAge != null && options.maxAge < 2) {
+  /* eslint-enable */
+    throw new Error(
+      'DevTools.instrument({ maxAge }) option, if specified, ' +
+      'may not be less than 2.'
+    );
+  }
+
   return createStore => (reducer, initialState, enhancer) => {
 
     function liftReducer(r) {

--- a/test/instrument.spec.js
+++ b/test/instrument.spec.js
@@ -479,6 +479,12 @@ describe('instrument', () => {
 
       spy.restore();
     });
+
+    it('should throw error when maxAge < 2', () => {
+      expect(() => {
+        createStore(counter, instrument(undefined, { maxAge: 1 }));
+      }).toThrow(/may not be less than 2/);
+    });
   });
 
   describe('Import State', () => {


### PR DESCRIPTION
`maxAge` with 1 breaks DevTools. Also, due to the @INIT action, it doesn't make sense to use anything < 2. 