### PR TITLE
Fix redux support for observables

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,15 +54,17 @@
     "react-addons-test-utils": "^0.14.0",
     "react-dom": "^0.14.0",
     "rimraf": "^2.3.4",
+    "rxjs": "^5.0.0-beta.6",
     "webpack": "^1.11.0"
   },
   "peerDependencies": {
-    "redux": "^3.0.0",
+    "redux": "^3.5.0",
     "react": "^0.14.0 || ^15.0.0-rc.1"
   },
   "dependencies": {
     "lodash": "^4.2.0",
     "react-redux": "^4.0.0",
-    "redux": "^3.2.1"
+    "redux": "^3.5.2",
+    "symbol-observable": "^0.2.4"
   }
 }

--- a/test/instrument.spec.js
+++ b/test/instrument.spec.js
@@ -1,6 +1,9 @@
 import expect, { spyOn } from 'expect';
 import { createStore, compose } from 'redux';
 import instrument, { ActionCreators } from '../src/instrument';
+import {Observable} from 'rxjs';
+
+import 'rxjs/add/observable/from';
 
 function counter(state = 0, action) {
   switch (action.type) {
@@ -51,6 +54,21 @@ describe('instrument', () => {
     expect(store.getState()).toBe(1);
     store.dispatch({ type: 'INCREMENT' });
     expect(store.getState()).toBe(2);
+  });
+
+  it('should provide observable', () => {
+    let lastValue;
+    let calls = 0;
+
+    Observable.from(store)
+        .subscribe(state => {
+          lastValue = state;
+          calls++;
+        });
+
+    expect(lastValue).toBe(0);
+    store.dispatch({ type: 'INCREMENT' });
+    expect(lastValue).toBe(1);
   });
 
   it('should rollback state to the last committed state', () => {


### PR DESCRIPTION
This change fixes the support for observables when store is instrumented by devtools. This will resolve  #274. To be honest, I am not sure if there is not a more elegant solution instead of reimplementing the subscribe function.