### PR TITLE
Master

### DIFF
--- a/examples/counter/package.json
+++ b/examples/counter/package.json
@@ -16,25 +16,26 @@
   },
   "homepage": "https://github.com/gaearon/redux-devtools#readme",
   "dependencies": {
-    "react": "^15.0.1",
-    "react-dom": "^15.0.1",
-    "react-hot-loader": "^3.0.0-beta.1",
-    "react-redux": "^4.1.0",
-    "redux": "^3.1.1",
-    "redux-thunk": "^1.0.3"
+    "react": "^15.2.0",
+    "react-dom": "^15.2.0",
+    "react-hot-loader": "^3.0.0-beta.2",
+    "react-redux": "^4.4.5",
+    "redux": "^3.5.2",
+    "redux-thunk": "^2.1.0"
   },
   "devDependencies": {
-    "babel-cli": "^6.3.17",
-    "babel-core": "^6.3.17",
-    "babel-loader": "^6.2.0",
-    "babel-preset-es2015-loose": "^6.1.3",
-    "babel-preset-react": "6.3.13",
-    "babel-preset-stage-0": "^6.3.13",
-    "node-libs-browser": "^0.5.2",
-    "redux-devtools": "^3.0.1",
-    "redux-devtools-dock-monitor": "^1.0.1",
-    "redux-devtools-log-monitor": "^1.0.2",
-    "webpack": "^1.9.11",
-    "webpack-dev-server": "^1.9.0"
+    "babel-cli": "^6.10.1",
+    "babel-core": "^6.10.4",
+    "babel-loader": "^6.2.4",
+    "babel-preset-es2015": "*",
+    "babel-preset-es2015-loose": "^7.0.0",
+    "babel-preset-react": "^6.11.1",
+    "babel-preset-stage-0": "^6.5.0",
+    "node-libs-browser": "^1.0.0",
+    "redux-devtools": "^3.3.1",
+    "redux-devtools-dock-monitor": "^1.1.1",
+    "redux-devtools-log-monitor": "^1.0.11",
+    "webpack": "^1.13.1",
+    "webpack-dev-server": "^1.14.1"
   }
 }

--- a/examples/counter/src/index.js
+++ b/examples/counter/src/index.js
@@ -7,20 +7,22 @@ import Root from './containers/Root';
 const store = configureStore();
 
 render(
-  <AppContainer
-    component={Root}
-    props={{ store }}
-  />,
+  <AppContainer>
+    <Root
+      store={ store }
+      />
+  </AppContainer>,
   document.getElementById('root')
 );
 
 if (module.hot) {
   module.hot.accept('./containers/Root', () => {
     render(
-      <AppContainer
-        component={require('./containers/Root').default}
-        props={{ store }}
-      />,
+      <AppContainer>
+        <Root
+          store={ store }
+          />
+      </AppContainer>,
       document.getElementById('root')
     );
   });

--- a/examples/counter/webpack.config.js
+++ b/examples/counter/webpack.config.js
@@ -19,7 +19,7 @@ module.exports = {
   ],
   resolve: {
     alias: {
-      'redux-devtools': path.join(__dirname, '..', '..', 'src'),
+      //'redux-devtools': path.join(__dirname, '..', '..', 'src'),
       'react': path.join(__dirname, 'node_modules', 'react')
     }
   },


### PR DESCRIPTION
The following warnings are fixed.
1) warning.js:44 Warning: Failed prop type: Passing "props" prop to
<AppContainer /> is deprecated. Replace <AppContainer component={App}
props={{ myProp: myValue }} /> with <AppContainer><App myProp={myValue}
/></AppContainer>.
in AppContainer

2) Warning: Failed prop type: Passing "component" prop to <AppContainer
/> is deprecated. Replace <AppContainer component={App} /> with
<AppContainer><App /></AppContainer>.
in AppContainer