### PR TITLE
Fixing deprecated issues in AppContainer

### DIFF
--- a/examples/counter/src/index.js
+++ b/examples/counter/src/index.js
@@ -7,20 +7,22 @@ import Root from './containers/Root';
 const store = configureStore();
 
 render(
-  <AppContainer
-    component={Root}
-    props={{ store }}
-  />,
+  <AppContainer>
+    <Root
+      store={ store }
+    />
+  </AppContainer>,
   document.getElementById('root')
 );
 
 if (module.hot) {
   module.hot.accept('./containers/Root', () => {
     render(
-      <AppContainer
-        component={require('./containers/Root').default}
-        props={{ store }}
-      />,
+      <AppContainer>
+        <Root
+          store={ store }
+        />
+      </AppContainer>,
       document.getElementById('root')
     );
   });

--- a/examples/todomvc/index.js
+++ b/examples/todomvc/index.js
@@ -8,20 +8,22 @@ import Root from './containers/Root';
 const store = configureStore();
 
 render(
-  <AppContainer
-    component={Root}
-    props={{ store }}
-  />,
+  <AppContainer>
+    <Root
+      store={ store }
+    />
+  </AppContainer>,
   document.getElementById('root')
 );
 
 if (module.hot) {
   module.hot.accept('./containers/Root', () => {
     render(
-      <AppContainer
-        component={require('./containers/Root').default}
-        props={{ store }}
-      />,
+      <AppContainer>
+        <Root
+          store={ store }
+        />
+      </AppContainer>,
       document.getElementById('root')
     );
   });


### PR DESCRIPTION
The following warnings are fixed.
1) warning.js:44 Warning: Failed prop type: Passing "props" prop to
<AppContainer /> is deprecated. Replace <AppContainer component={App}
props={{ myProp: myValue }} /> with <AppContainer><App myProp={myValue}
/></AppContainer>.
in AppContainer

2) Warning: Failed prop type: Passing "component" prop to <AppContainer
/> is deprecated. Replace <AppContainer component={App} /> with
<AppContainer><App /></AppContainer>.
in AppContainer