### PR TITLE
Allow react-redux 5 in peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,17 +54,18 @@
     "react": "^0.14.0",
     "react-addons-test-utils": "^0.14.0",
     "react-dom": "^0.14.0",
+    "react-redux": "^4.0.0",
+    "redux": "^3.5.2",
     "rimraf": "^2.3.4",
     "webpack": "^1.11.0"
   },
   "peerDependencies": {
-    "redux": "^3.5.0",
-    "react": "^0.14.0 || ^15.0.0-rc.1"
+    "react": "^0.14.0 || ^15.0.0",
+    "react-redux": "^4.0.0 || ^5.0.0",
+    "redux": "^3.5.2"
   },
   "dependencies": {
     "lodash": "^4.2.0",
-    "react-redux": "^4.0.0",
-    "redux": "^3.5.2",
     "redux-devtools-instrument": "^1.0.1"
   }
 }


### PR DESCRIPTION
This allows users to upgrade to the API-compatible v5 of react-redux without encumbering their `node_modules` with a nested copy of react-redux (v4) under `redux-devtools/node_modules`.

It also moves redux and react-redux into `devDependencies`, which is the proper location for packages that are also specified in `peerDependencies`. Otherwise, peers specified as an alternating range (`||`) won't resolve properly. This brings it in line with what [react-redux does](https://github.com/reactjs/react-redux/blob/master/package.json#L94-L107).