### PR TITLE
fixed PropTypes warnings

### DIFF
--- a/examples/counter/package.json
+++ b/examples/counter/package.json
@@ -16,7 +16,8 @@
   },
   "homepage": "https://github.com/gaearon/redux-devtools#readme",
   "dependencies": {
-    "react": "^15.0.1",
+    "prop-types": "^15.5.7",
+    "react": "^15.3.0",
     "react-dom": "^15.0.1",
     "react-hot-loader": "^3.0.0-beta.1",
     "react-redux": "^4.1.0",

--- a/examples/counter/src/components/Counter.js
+++ b/examples/counter/src/components/Counter.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 export default class Counter extends Component {
   static propTypes = {

--- a/examples/todomvc/components/Footer.js
+++ b/examples/todomvc/components/Footer.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { SHOW_ALL, SHOW_MARKED, SHOW_UNMARKED } from '../constants/TodoFilters';
 

--- a/examples/todomvc/components/Header.js
+++ b/examples/todomvc/components/Header.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import TodoTextInput from './TodoTextInput';
 
 export default class Header extends Component {

--- a/examples/todomvc/components/MainSection.js
+++ b/examples/todomvc/components/MainSection.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import TodoItem from './TodoItem';
 import Footer from './Footer';
 import { SHOW_ALL, SHOW_MARKED, SHOW_UNMARKED } from '../constants/TodoFilters';

--- a/examples/todomvc/components/TodoItem.js
+++ b/examples/todomvc/components/TodoItem.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import TodoTextInput from './TodoTextInput';
 

--- a/examples/todomvc/components/TodoTextInput.js
+++ b/examples/todomvc/components/TodoTextInput.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
 export default class TodoTextInput extends Component {

--- a/examples/todomvc/package.json
+++ b/examples/todomvc/package.json
@@ -29,7 +29,8 @@
   "homepage": "https://github.com/gaearon/redux-devtools#readme",
   "dependencies": {
     "classnames": "^2.1.2",
-    "react": "^15.0.1",
+    "prop-types": "^15.5.7",
+    "react": "^15.3.0",
     "react-dom": "^15.0.1",
     "react-hot-loader": "^3.0.0-beta.1",
     "react-redux": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "mocha": "^2.2.5",
     "mocha-jsdom": "^1.0.0",
     "react": "^0.14.9",
-    "prop-types": "^15.5.0",
+    "prop-types": "^15.5.7",
     "react-addons-test-utils": "^0.14.0",
     "react-dom": "^0.14.0",
     "react-redux": "^4.0.0",
@@ -62,11 +62,12 @@
   },
   "peerDependencies": {
     "react": "^0.14.9 || ^15.3.0",
-    "prop-types": "^15.5.0",
+    "prop-types": "^15.5.7",
     "react-redux": "^4.0.0 || ^5.0.0",
     "redux": "^3.5.2"
   },
   "dependencies": {
+    "prop-types": "^15.5.7",
     "lodash": "^4.2.0",
     "redux-devtools-instrument": "^1.0.1"
   }

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "jsdom": "^6.5.1",
     "mocha": "^2.2.5",
     "mocha-jsdom": "^1.0.0",
-    "react": "^0.14.0",
+    "react": "^0.14.9",
     "prop-types": "^15.5.0",
     "react-addons-test-utils": "^0.14.0",
     "react-dom": "^0.14.0",
@@ -61,7 +61,8 @@
     "webpack": "^1.11.0"
   },
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0",
+    "react": "^0.14.9 || ^15.3.0",
+    "prop-types": "^15.5.0",
     "react-redux": "^4.0.0 || ^5.0.0",
     "redux": "^3.5.2"
   },

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "mocha": "^2.2.5",
     "mocha-jsdom": "^1.0.0",
     "react": "^0.14.0",
+    "prop-types": "^15.5.0",
     "react-addons-test-utils": "^0.14.0",
     "react-dom": "^0.14.0",
     "react-redux": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "mocha": "^2.2.5",
     "mocha-jsdom": "^1.0.0",
     "react": "^0.14.9",
-    "prop-types": "^15.5.7",
     "react-addons-test-utils": "^0.14.0",
     "react-dom": "^0.14.0",
     "react-redux": "^4.0.0",
@@ -62,7 +61,6 @@
   },
   "peerDependencies": {
     "react": "^0.14.9 || ^15.3.0",
-    "prop-types": "^15.5.7",
     "react-redux": "^4.0.0 || ^5.0.0",
     "redux": "^3.5.2"
   },

--- a/src/createDevTools.js
+++ b/src/createDevTools.js
@@ -1,4 +1,5 @@
-import React, { Children, Component, PropTypes } from 'react';
+import React, { Children, Component } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import instrument from 'redux-devtools-instrument';
 


### PR DESCRIPTION
Removed Warning: Accessing PropTypes via the main React package is deprecated. Use the prop-types package from npm instead.