### PR TITLE
Upgrade webpack to version to 2

### DIFF
--- a/examples/counter/package.json
+++ b/examples/counter/package.json
@@ -35,7 +35,7 @@
     "redux-devtools": "^3.0.1",
     "redux-devtools-dock-monitor": "^1.0.1",
     "redux-devtools-log-monitor": "^1.0.2",
-    "webpack": "^1.9.11",
-    "webpack-dev-server": "^1.9.0"
+    "webpack": "^2.5.1",
+    "webpack-dev-server": "^2.4.5"
   }
 }

--- a/examples/counter/webpack.config.js
+++ b/examples/counter/webpack.config.js
@@ -24,17 +24,17 @@ module.exports = {
     }
   },
   resolveLoader: {
-    'fallback': path.join(__dirname, 'node_modules')
+    'modules': [path.join(__dirname, 'node_modules')]
   },
   module: {
     loaders: [{
       test: /\.js$/,
-      loaders: ['babel'],
+      loaders: ['babel-loader'],
       exclude: /node_modules/,
       include: path.join(__dirname, 'src')
     }, {
       test: /\.js$/,
-      loaders: ['babel'],
+      loaders: ['babel-loader'],
       include: path.join(__dirname, '..', '..', 'src')
     }]
   }


### PR DESCRIPTION
Upgrade webpack to version to 2. 
This provides better support for file change detection and hot module reloading on Linux. 